### PR TITLE
Add redirect for broken Babel comparison link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -94,6 +94,11 @@ module.exports = withNextra({
         permanent: true,
       },
       {
+        source: "/docs/comparison-babel",
+        destination: "/docs/migrating-from-babel",
+        permanent: true,
+      },
+      {
         source: "/docs/benchmark-autogen",
         destination: "/docs/benchmarks",
         permanent: true,


### PR DESCRIPTION
`Issue`: Currently, the swc project's README incorrectly points to https://swc.rs/docs/comparison-babel for a Babel comparison.
`Expected Behavior`: The link should point to https://swc.rs/docs/migrating-from-babel
`Resolution`: The broken link can either be resolved via redirect here or by changing the link in the README. I have made pull requests for both and will create an issue in the main project repo linking to those pull requests.